### PR TITLE
added GitHub Action for automatic PYPI deployment

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,40 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@master
+    
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true


### PR DESCRIPTION
This should *NOT* be merged until:
- the repo is first pushed to PYPI
- an authentication token has been generated for the respective package, and added to GitHub Secrets as `PYPI_API_TOKEN`